### PR TITLE
Add basic tox jobs

### DIFF
--- a/.github/workflows/toxjobs.yml
+++ b/.github/workflows/toxjobs.yml
@@ -1,0 +1,27 @@
+name: Run tox jobs
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  tox:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9']
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install tox
+    - name: Run lint jobs
+      run: tox -e pep8
+    - name: Run packaging jobs
+      run: tox -e packaging
+    - name: Run unit tests
+      run: tox -e py3

--- a/README.rst
+++ b/README.rst
@@ -14,22 +14,22 @@ require that to work sanely.
 
 Examples
 --------
-Install TripleO CI testing repos for UBI-8 by the distro specific path::
+Install Podified CI testing repos for UBI-8 by the distro specific path::
 
-    repo-setup -d ubi8 repo-setup-ci-testing --output-path /etc/distro.repos.d
+    repo-setup -d ubi8 podified-ci-testing --output-path /etc/distro.repos.d
 
 Install current master RDO Trunk repo and the deps repo::
 
     repo-setup current
 
-Install current-tripleo RDO Trunk repo and the deps repo::
+Install current-podified RDO Trunk repo and the deps repo::
 
-    repo-setup current-tripleo
+    repo-setup current-podified
 
-Install the current-repo-setup-dev repo. This will also pull current and deps,
+Install the current-podified-dev repo. This will also pull current and deps,
 and will adjust the priorities of each repo appropriately::
 
-    repo-setup current-repo-setup-dev
+    repo-setup current-podified-dev
 
 Install the mitaka RDO Trunk repo and deps::
 
@@ -39,32 +39,7 @@ Write repos to a different path::
 
     repo-setup -o ~/test-repos current
 
-Install the current-tripleo, deps, and ceph repos. NOTE: The Ceph repo is
+Install the current-podified, deps, and ceph repos. NOTE: The Ceph repo is
 installed from a package and thus does not respect -o::
 
-    repo-setup current-tripleo ceph
-
-TripleO
-```````
-
-To use this for TripleO development, replace the tripleo.sh --repo-setup
-step with the following::
-
-    git clone https://github.com/cybertron/repo-setup
-    cd repo-setup
-    sudo ./setup.py install
-    sudo repo-setup current-repo-setup-dev ceph
-
-Now you're ready to install the undercloud::
-
-    tripleo.sh --undercloud
-
-And to build images::
-
-    export OVERCLOUD_IMAGES_DIB_YUM_REPO_CONF="$(ls /etc/yum.repos.d/delorean* /etc/yum.repos.d/CentOS-Ceph-*)"
-    tripleo.sh --overcloud-images
-
-.. note:: This is a tool for bootstrapping the repo setup for TripleO,
-    so it should not have any runtime OpenStack dependencies
-    or we end up in a chicken-and-egg pickle, and let's be honest - no one wants a
-    chicken and egg pickle.
+    repo-setup current-podified ceph

--- a/playbooks/example_get_hash.yaml
+++ b/playbooks/example_get_hash.yaml
@@ -7,7 +7,7 @@
         os_version: centos8       # default: centos8
         release: victoria         # default: master
         component: compute        # default: None
-        tag: component-ci-testing   # default: current-tripleo
+        tag: component-ci-testing # default: current-podified
       register: component_ci_testing_victoria_compute
 
     - debug:
@@ -16,25 +16,25 @@
     - debug:
         var: component_ci_testing_victoria_compute
 
-    - name: get centos7 repo-setup-ci-testing for train
+    - name: get centos9 podified-ci-testing for zed
       repo_setup.repos.get_hash:
-        os_version: centos7
-        release: train
-        tag: repo-setup-ci-testing
-      register: centos7_repo_setup_ci_testing_train
+        os_version: centos9
+        release: zed
+        tag: podified-ci-testing
+      register: centos9_podified_ci_testing_zed
 
     - debug:
-        msg: "Centos7 current-tripleo train: {{ centos7_repo_setup_ci_testing_train['full_hash'] }}"
+        msg: "Centos9 podified-ci-testing zed: {{ centos9_podified_ci_testing_zed['full_hash'] }}"
 
     - debug:
-        var: centos7_repo_setup_ci_testing_train
+        var: centos9_repo_setup_ci_testing_zed
 
-    - name: get current-tripleo centos8 for master branch
+    - name: get current-podified centos9 for master branch
       repo_setup.repos.get_hash:
-      register: centos8_current_repo_setup_master
+      register: centos9_current_repo_setup_master
 
     - debug:
-        msg: "Centos8 current-tripleo master: {{ centos8_current_repo_setup_master['full_hash'] }}"
+        msg: "Centos9 current-podified master: {{ centos9_current_repo_setup_master['full_hash'] }}"
 
     - debug:
-        var: centos8_current_repo_setup_master
+        var: centos9_current_repo_setup_master

--- a/plugins/module_utils/repo_setup/get_hash/__main__.py
+++ b/plugins/module_utils/repo_setup/get_hash/__main__.py
@@ -52,7 +52,7 @@ def main():
     )
     parser.add_argument(
         "--tag",
-        default="current-tripleo",
+        default="current-podified",
         choices=config["rdo_named_tags"],
         help=("The known tag to retrieve the hash_info for"),
     )
@@ -110,6 +110,7 @@ def main():
     else:
         print(repo_setup_hash_info)
         return repo_setup_hash_info
+
 
 def cli_entrypoint():
     try:

--- a/plugins/module_utils/repo_setup/get_hash/constants.py
+++ b/plugins/module_utils/repo_setup/get_hash/constants.py
@@ -58,9 +58,9 @@ DEFAULT_CONFIG = {
         "consistent",
         "component-ci-testing",
         "promoted-components",
-        "repo-setup-ci-testing",
-        "current-tripleo",
-        "current-repo-setup-rdo",
+        "podified-ci-testing",
+        "current-podified",
+        "current-podified-rdo",
     ],
     "repo_setup_ci_components": [
         "baremetal",

--- a/plugins/module_utils/repo_setup/get_hash/hash_info.py
+++ b/plugins/module_utils/repo_setup/get_hash/hash_info.py
@@ -37,7 +37,7 @@ class HashInfo:
     represent a particular delorean build hash. This includes the full, commit,
     distro and extended hashes (where applicable), as well as the release,
     OS name and version, component name (if applicable), named tag
-    (current-tripleo, repo-setup-ci-testing etc) as well as the URL to the
+    (current-podified, podified-testing etc) as well as the URL to the
     delorean server that provided the information used to build each object
     instance.
     """
@@ -125,8 +125,8 @@ class HashInfo:
 
         :param os_version: The OS and version e.g. centos8
         :param release: The OpenStack release e.g. wallaby
-        :param component: The repo-setup-ci component e.g. 'common' or None
-        :param tag: The Delorean server named tag e.g. current-tripleo
+        :param component: The podified-ci component e.g. 'common' or None
+        :param tag: The Delorean server named tag e.g. current-podified
         :param config: Use an existing config dictionary and don't load it
         """
         config = HashInfo.load_config(config)
@@ -166,9 +166,9 @@ class HashInfo:
         """Resolve the delorean server URL given the various attributes of
         this HashInfo object. The only passed parameter is the
         dlrn_url. There are three main cases:
-            * centos8/rhel8 component https://trunk.rdoproject.org/centos8/component/common/current-tripleo/commit.yaml
-            * centos7 https://trunk.rdoproject.org/centos7/current-tripleo/commit.yaml
-            * centos8/rhel8 non component https://trunk.rdoproject.org/centos8/current-tripleo/delorean.repo.md5
+            * centos8/rhel8 component https://trunk.rdoproject.org/centos8/component/common/current-podified/commit.yaml
+            * centos7 https://trunk.rdoproject.org/centos7/current-podified/commit.yaml
+            * centos8/rhel8 non component https://trunk.rdoproject.org/centos8/current-podified/delorean.repo.md5
         Returns a string which is the full URL to the required item (i.e.
         commit.yaml or repo.md5 depending on the case).
 

--- a/plugins/module_utils/repo_setup/main.py
+++ b/plugins/module_utils/repo_setup/main.py
@@ -359,7 +359,7 @@ def _validate_current_repos(repos):
     return True
 
 
-def _validate_repo_setup_ci_testing(repos):
+def _validate_podified_ci_testing(repos):
     """Validate podified-ci-testing
 
     With podified-ci-testing for repo (currently only periodic container build)
@@ -410,7 +410,7 @@ def _validate_distro_stream(args, distro_name, distro_major_version_id):
 def _validate_args(args, distro_name, distro_major_version_id):
     _validate_current_repos(args.repos)
     _validate_distro_repos(args)
-    _validate_repo_setup_ci_testing(args.repos)
+    _validate_podified_ci_testing(args.repos)
     _validate_distro_stream(args, distro_name, distro_major_version_id)
 
 
@@ -532,6 +532,7 @@ def _inject_mirrors(content, args):
 
     return content
 
+
 def _get_rhel_trunk_candidate_repos(args, base_path):
     content = _get_repo(base_path + "osptrunk-deps.repo", args)
     # Replace deps with candidate
@@ -543,6 +544,7 @@ def _get_rhel_trunk_candidate_repos(args, base_path):
     content.remove('module_hotfixes=1')
     content = '\n'.join(content)
     return content
+
 
 def _install_repos(args, base_path):
     def install_deps(args, base_path):

--- a/plugins/modules/get_hash.py
+++ b/plugins/modules/get_hash.py
@@ -37,7 +37,7 @@ options:
         description: The named tag to fetch
         required: false
         type: str
-        default: current-tripleo
+        default: current-podified
     dlrn_url:
         description: The url of the DLRN server to use for hash queries
         required: false
@@ -82,7 +82,7 @@ dlrn_url:
     description: The dlrn server url from which hash info was collected.
     type: str
     returned: always
-    sample: 'https://trunk.rdoproject.org/centos8-master/current-tripleo/delorean.repo.md5'  # noqa E501
+    sample: 'https://trunk.rdoproject.org/centos8-master/current-podified/delorean.repo.md5'  # noqa E501
 """
 
 from ansible.module_utils.basic import AnsibleModule  # noqa: E402
@@ -99,7 +99,7 @@ def run_module():
         os_version=dict(type="str", required=False, default="centos8"),
         release=dict(type="str", required=False, default="master"),
         component=dict(type="str", required=False, default=None),
-        tag=dict(type="str", required=False, default="current-tripleo"),
+        tag=dict(type="str", required=False, default="current-podified"),
         dlrn_url=dict(
             type="str", required=False, default="https://trunk.rdoproject.org"
         ),

--- a/roles/build-test-packages/library/jenkins_deps.py
+++ b/roles/build-test-packages/library/jenkins_deps.py
@@ -16,7 +16,7 @@ import json
 import logging
 import re
 import requests
-from ansible.module_utils.basic import *
+from ansible.module_utils.basic import *  # noqa
 
 
 DOCUMENTATION = '''
@@ -210,7 +210,7 @@ def resolve_dep(host, change_id, branch, revision):
 
 
 def main():
-    module = AnsibleModule(
+    module = AnsibleModule(  # noqa
         argument_spec=dict(
             host=dict(required=True, type='str'),
             change_id=dict(required=True, type='str'),

--- a/roles/repo-setup/defaults/main.yml
+++ b/roles/repo-setup/defaults/main.yml
@@ -65,9 +65,9 @@ known_hash_tags:
   - current
   - consistent
   - tripleo-ci-testing
-  - current-tripleo
-  - current-tripleo-rdo
-  - current-tripleo-rdo-internal
+  - current-podified
+  - current-podified-rdo
+  - current-podified-rdo-internal
   - current-passed-ci
   - promoted-components
   - component-ci-testing

--- a/tests/unit/get_hash/fakes.py
+++ b/tests/unit/get_hash/fakes.py
@@ -101,9 +101,9 @@ rdo_named_tags:
   - current
   - consistent
   - component-ci-testing
-  - repo-setup-ci-testing
-  - current-tripleo
-  - current-repo-setup-rdo
+  - podified-ci-testing
+  - current-podified
+  - current-podified-rdo
 
 os_versions:
   - centos7

--- a/tests/unit/get_hash/test_get_hash.py
+++ b/tests/unit/get_hash/test_get_hash.py
@@ -39,13 +39,13 @@ class TestGetHash(unittest.TestCase):
         mocked = MagicMock(
             return_value=(test_fakes.TEST_REPO_MD5, 200))
         with patch(
-                'repo_setup.get_hash.repo_setup_hash_info.http_get', mocked):
+                'repo_setup.get_hash.hash_info.http_get', mocked):
             args = ['--os-version', 'centos8', '--release', 'victoria']
             sys.argv[1:] = args
             main_res = tgh.main()
             self.assertEqual(main_res.full_hash, test_fakes.TEST_REPO_MD5)
             self.assertEqual(
-                'https://trunk.rdoproject.org/centos8-victoria/current-tripleo/delorean.repo.md5',  # noqa
+                'https://trunk.rdoproject.org/centos8-victoria/current-podified/delorean.repo.md5',  # noqa
                 main_res.dlrn_url,
             )
             self.assertEqual('centos8', main_res.os_version)
@@ -59,7 +59,7 @@ class TestGetHash(unittest.TestCase):
 #        mocked = MagicMock(
 #            return_value=(test_fakes.TEST_REPO_MD5, 200))
 #        with patch(
-#                'repo_setup.get_hash.repo_setup_hash_info.http_get', mocked):
+#                'repo_setup.get_hash.hash_info.http_get', mocked):
 #            with self.assertLogs() as captured:
 #                sys.argv[1:] = args
 #                tgh.main()
@@ -76,9 +76,9 @@ class TestGetHash(unittest.TestCase):
 #        mocked = MagicMock(
 #            return_value=(test_fakes.TEST_REPO_MD5, 200))
 #        with patch(
-#                'repo_setup.get_hash.repo_setup_hash_info.http_get', mocked):
+#                'repo_setup.get_hash.hash_info.http_get', mocked):
 #
-#            args = ['--tag', 'current-tripleo', '--os-version', 'centos8']
+#            args = ['--tag', 'current-podified', '--os-version', 'centos8']
 #            with self.assertLogs() as captured:
 #                sys.argv[1:] = args
 #                tgh.main()
@@ -104,7 +104,7 @@ class TestGetHash(unittest.TestCase):
             mocked = MagicMock(
                 return_value=(test_fakes.TEST_COMMIT_YAML_COMPONENT, 200))
             with patch(
-                    'repo_setup.get_hash.repo_setup_hash_info.http_get',
+                    'repo_setup.get_hash.hash_info.http_get',
                     mocked):
 
                 args = ['--component', "{}".format(component)]
@@ -112,7 +112,7 @@ class TestGetHash(unittest.TestCase):
                 main_res = tgh.main()
                 self.assertEqual(
                     "https://trunk.rdoproject.org/centos8-master/component"
-                    "/{}/current-tripleo/commit.yaml".format(
+                    "/{}/current-podified/commit.yaml".format(
                         component
                     ),
                     main_res.dlrn_url,
@@ -135,17 +135,17 @@ class TestGetHash(unittest.TestCase):
                     return_value=(test_fakes.TEST_COMMIT_YAML_CENTOS_7, 200))
                 expected_url = (
                     "https://trunk.rdoproject.org/{}-master/"
-                    "current-tripleo/commit.yaml".format(os_v)
+                    "current-podified/commit.yaml".format(os_v)
                 )
             else:
                 mocked = MagicMock(
                     return_value=(test_fakes.TEST_REPO_MD5, 200))
                 expected_url = (
                     "https://trunk.rdoproject.org/{}-master/"
-                    "current-tripleo/delorean.repo.md5".format(os_v)
+                    "current-podified/delorean.repo.md5".format(os_v)
                 )
             with patch(
-                    'repo_setup.get_hash.repo_setup_hash_info.http_get',
+                    'repo_setup.get_hash.hash_info.http_get',
                     mocked):
                 args = ['--os-version', "{}".format(os_v)]
                 sys.argv[1:] = args
@@ -172,7 +172,7 @@ class TestGetHash(unittest.TestCase):
             mocked = MagicMock(
                 return_value=(test_fakes.TEST_REPO_MD5, 200))
             with patch(
-                    'repo_setup.get_hash.repo_setup_hash_info.http_get',
+                    'repo_setup.get_hash.hash_info.http_get',
                     mocked):
 
                 args = ['--tag', "{}".format(tag)]
@@ -191,14 +191,14 @@ class TestGetHash(unittest.TestCase):
         mocked = MagicMock(
             return_value=(test_fakes.TEST_REPO_MD5, 200))
         with patch(
-                'repo_setup.get_hash.repo_setup_hash_info.http_get',
+                'repo_setup.get_hash.hash_info.http_get',
                 mocked):
 
             args = ['--dlrn-url', 'https://awoo.com/awoo']
             sys.argv[1:] = args
             main_res = tgh.main()
             self.assertEqual(
-                "https://awoo.com/awoo/centos8-master/current-tripleo"
+                "https://awoo.com/awoo/centos8-master/current-podified"
                 "/delorean.repo.md5",
                 main_res.dlrn_url,
             )
@@ -207,7 +207,7 @@ class TestGetHash(unittest.TestCase):
         mocked = MagicMock(
             return_value=(test_fakes.TEST_REPO_MD5, 200))
         with patch(
-                'repo_setup.get_hash.repo_setup_hash_info.http_get',
+                'repo_setup.get_hash.hash_info.http_get',
                 mocked):
             args = [
                 '--dlrn-url',
@@ -222,7 +222,7 @@ class TestGetHash(unittest.TestCase):
             self.assertEqual('rhel8', main_res.os_version)
             self.assertEqual('osp16-2', main_res.release)
             self.assertEqual(
-                "https://awoo.com/awoo/rhel8-osp16-2/current-tripleo"
+                "https://awoo.com/awoo/rhel8-osp16-2/current-podified"
                 "/delorean.repo.md5", main_res.dlrn_url,
             )
 

--- a/tests/unit/get_hash/test_get_hash_info.py
+++ b/tests/unit/get_hash/test_get_hash_info.py
@@ -15,7 +15,7 @@
 #
 
 import unittest
-import repo_setup.get_hash.repo_setup_hash_info as thi
+import repo_setup.get_hash.hash_info as thi
 import repo_setup.get_hash.exceptions as exc
 from . import fakes as test_fakes
 from unittest import mock
@@ -43,9 +43,9 @@ class TestGetHashInfo(unittest.TestCase):
         mocked = MagicMock(
             return_value=(test_fakes.TEST_COMMIT_YAML_COMPONENT, 200))
         with patch(
-                'repo_setup.get_hash.repo_setup_hash_info.http_get', mocked):
+                'repo_setup.get_hash.hash_info.http_get', mocked):
             mock_hash_info = thi.HashInfo(
-                'centos8', 'master', 'common', 'current-tripleo'
+                'centos8', 'master', 'common', 'current-podified'
             )
             actual_result = mock_hash_info._hashes_from_commit_yaml(
                 sample_commit_yaml
@@ -56,27 +56,27 @@ class TestGetHashInfo(unittest.TestCase):
         mocked = MagicMock(
             return_value=(test_fakes.TEST_COMMIT_YAML_COMPONENT, 200))
         with patch(
-                'repo_setup.get_hash.repo_setup_hash_info.http_get', mocked):
+                'repo_setup.get_hash.hash_info.http_get', mocked):
             c8_component_hash_info = thi.HashInfo(
-                'centos8', 'master', 'common', 'current-tripleo'
+                'centos8', 'master', 'common', 'current-podified'
             )
             repo_url = c8_component_hash_info._resolve_repo_url("https://woo")
             self.assertEqual(
                 repo_url,
-                'https://woo/centos8-master/component/common/current-tripleo/commit.yaml',  # noqa
+                'https://woo/centos8-master/component/common/current-podified/commit.yaml',  # noqa
             )
 
     def test_resolve_repo_url_centos8_repo_md5(self, mock_config):
         mocked = MagicMock(
             return_value=(test_fakes.TEST_REPO_MD5, 200))
         with patch(
-                'repo_setup.get_hash.repo_setup_hash_info.http_get', mocked):
-            c8_hash_info = thi.TripleOHashInfo(
-                'centos8', 'master', None, 'current-tripleo'
+                'repo_setup.get_hash.hash_info.http_get', mocked):
+            c8_hash_info = thi.HashInfo(
+                'centos8', 'master', None, 'current-podified'
             )
             repo_url = c8_hash_info._resolve_repo_url("https://woo")
             self.assertEqual(
-                repo_url, 'https://woo/centos8-master/current-tripleo/delorean.repo.md5'  # noqa
+                repo_url, 'https://woo/centos8-master/current-podified/delorean.repo.md5'  # noqa
 
             )
 
@@ -84,44 +84,44 @@ class TestGetHashInfo(unittest.TestCase):
         mocked = MagicMock(
             return_value=(test_fakes.TEST_COMMIT_YAML_CENTOS_7, 200))
         with patch(
-                'repo_setup.get_hash.repo_setup_hash_info.http_get', mocked):
-            c7_hash_info = thi.TripleOHashInfo(
-                'centos7', 'master', None, 'current-tripleo'
+                'repo_setup.get_hash.hash_info.http_get', mocked):
+            c7_hash_info = thi.HashInfo(
+                'centos7', 'master', None, 'current-podified'
             )
             repo_url = c7_hash_info._resolve_repo_url("https://woo")
             self.assertEqual(
-                repo_url, 'https://woo/centos7-master/current-tripleo/commit.yaml'  # noqa
+                repo_url, 'https://woo/centos7-master/current-podified/commit.yaml'  # noqa
 
             )
 
-    def test_get_repo_setup_hash_info_centos8_md5(self, mock_config):
+    def test_get_hash_info_centos8_md5(self, mock_config):
         mocked = MagicMock(
             return_value=(test_fakes.TEST_REPO_MD5, 200))
         with patch(
-                'repo_setup.get_hash.repo_setup_hash_info.http_get', mocked):
-            created_hash_info = thi.TripleOHashInfo(
-                'centos8', 'master', None, 'current-tripleo'
+                'repo_setup.get_hash.hash_info.http_get', mocked):
+            created_hash_info = thi.HashInfo(
+                'centos8', 'master', None, 'current-podified'
             )
-            self.assertIsInstance(created_hash_info, thi.TripleOHashInfo)
+            self.assertIsInstance(created_hash_info, thi.HashInfo)
             self.assertEqual(
                 created_hash_info.full_hash, test_fakes.TEST_REPO_MD5
             )
-            self.assertEqual(created_hash_info.tag, 'current-tripleo')
+            self.assertEqual(created_hash_info.tag, 'current-podified')
             self.assertEqual(created_hash_info.os_version, 'centos8')
             self.assertEqual(created_hash_info.release, 'master')
 
-    def test_get_repo_setup_hash_info_component(self, mock_config):
+    def test_get_hash_info_component(self, mock_config):
         expected_commit_hash = '476a52df13202a44336c8b01419f8b73b93d93eb'
         expected_distro_hash = '1f5a41f31db8e3eb51caa9c0e201ab0583747be8'
         expected_full_hash = '476a52df13202a44336c8b01419f8b73b93d93eb_1f5a41f3'  # noqa
         mocked = MagicMock(
             return_value=(test_fakes.TEST_COMMIT_YAML_COMPONENT, 200))
         with patch(
-                'repo_setup.get_hash.repo_setup_hash_info.http_get', mocked):
-            created_hash_info = thi.TripleOHashInfo(
-                'centos8', 'victoria', 'common', 'repo-setup-ci-testing'
+                'repo_setup.get_hash.hash_info.http_get', mocked):
+            created_hash_info = thi.HashInfo(
+                'centos8', 'victoria', 'common', 'podified-ci-testing'
             )
-            self.assertIsInstance(created_hash_info, thi.TripleOHashInfo)
+            self.assertIsInstance(created_hash_info, thi.HashInfo)
             self.assertEqual(created_hash_info.full_hash, expected_full_hash)
             self.assertEqual(
                 created_hash_info.distro_hash, expected_distro_hash
@@ -130,21 +130,21 @@ class TestGetHashInfo(unittest.TestCase):
                 created_hash_info.commit_hash, expected_commit_hash
             )
             self.assertEqual(created_hash_info.component, 'common')
-            self.assertEqual(created_hash_info.tag, 'repo-setup-ci-testing')
+            self.assertEqual(created_hash_info.tag, 'podified-ci-testing')
             self.assertEqual(created_hash_info.release, 'victoria')
 
-    def test_get_repo_setup_hash_info_centos7_commit_yaml(self, mock_config):
+    def test_get_hash_info_centos7_commit_yaml(self, mock_config):
         expected_commit_hash = 'b5ef03c9c939db551b03e9490edc6981ff582035'
         expected_distro_hash = '76ebc4655502820b7677579349fd500eeca292e6'
         expected_full_hash = 'b5ef03c9c939db551b03e9490edc6981ff582035_76ebc465'  # noqa
         mocked = MagicMock(
             return_value=(test_fakes.TEST_COMMIT_YAML_CENTOS_7, 200))
         with patch(
-                'repo_setup.get_hash.repo_setup_hash_info.http_get', mocked):
-            created_hash_info = thi.TripleOHashInfo(
-                'centos7', 'master', None, 'repo-setup-ci-testing'
+                'repo_setup.get_hash.hash_info.http_get', mocked):
+            created_hash_info = thi.HashInfo(
+                'centos7', 'master', None, 'podified-ci-testing'
             )
-            self.assertIsInstance(created_hash_info, thi.TripleOHashInfo)
+            self.assertIsInstance(created_hash_info, thi.HashInfo)
             self.assertEqual(created_hash_info.full_hash, expected_full_hash)
             self.assertEqual(
                 created_hash_info.distro_hash, expected_distro_hash
@@ -158,60 +158,60 @@ class TestGetHashInfo(unittest.TestCase):
         mocked = MagicMock(
             return_value=test_fakes.TEST_COMMIT_YAML_CENTOS_7)
         with patch(
-                'repo_setup.get_hash.repo_setup_hash_info.http_get', mocked):
+                'repo_setup.get_hash.hash_info.http_get', mocked):
             with mock.patch(
                 'builtins.open',
                 new_callable=mock_open,
                 read_data=test_fakes.BAD_CONFIG_FILE,
             ):
                 self.assertRaises(
-                    exc.TripleOHashInvalidConfig,
-                    thi.TripleOHashInfo,
+                    exc.HashInvalidConfig,
+                    thi.HashInfo,
                     'centos7',
                     'master',
                     None,
-                    'repo-setup-ci-testing',
+                    'podified-ci-testing',
                 )
 
     def test_override_config_dlrn_url(self, mock_config):
-        expected_dlrn_url = 'https://foo.bar.baz/centos8-master/component/common/current-tripleo/commit.yaml'  # noqa
+        expected_dlrn_url = 'https://foo.bar.baz/centos8-master/component/common/current-podified/commit.yaml'  # noqa
         mocked = MagicMock(
             return_value=(test_fakes.TEST_COMMIT_YAML_COMPONENT, 200))
         with patch(
-                'repo_setup.get_hash.repo_setup_hash_info.http_get', mocked):
-            mock_hash_info = thi.TripleOHashInfo(
-                'centos8', 'master', 'common', 'current-tripleo',
+                'repo_setup.get_hash.hash_info.http_get', mocked):
+            mock_hash_info = thi.HashInfo(
+                'centos8', 'master', 'common', 'current-podified',
                 {'dlrn_url': 'https://foo.bar.baz'}
             )
             self.assertEqual(expected_dlrn_url, mock_hash_info.dlrn_url)
 
     def test_override_config_dlrn_url_empty_ignored(self, mock_config):
-        expected_dlrn_url = 'https://trunk.rdoproject.org/centos8-master/component/common/current-tripleo/commit.yaml'  # noqa
+        expected_dlrn_url = 'https://trunk.rdoproject.org/centos8-master/component/common/current-podified/commit.yaml'  # noqa
         mocked = MagicMock(
             return_value=(test_fakes.TEST_COMMIT_YAML_COMPONENT, 200))
         with patch(
-                'repo_setup.get_hash.repo_setup_hash_info.http_get', mocked):
-            mock_hash_info = thi.TripleOHashInfo(
-                'centos8', 'master', 'common', 'current-tripleo',
+                'repo_setup.get_hash.hash_info.http_get', mocked):
+            mock_hash_info = thi.HashInfo(
+                'centos8', 'master', 'common', 'current-podified',
                 {'dlrn_url': ''}
             )
             self.assertEqual(expected_dlrn_url, mock_hash_info.dlrn_url)
 
     def test_404_dlrn_http_status_code(self, mock_config):
-        bad_dlrn_url = 'https://server.ok/centos8-master/component/common/current-tripleo/commit.yaml'  # noqa
+        bad_dlrn_url = 'https://server.ok/centos8-master/component/common/current-podified/commit.yaml'  # noqa
         response_text_404 = "Some kind of 404 text NOT FOUND!"
         mocked = MagicMock(
             return_value=(response_text_404, 404))
         with patch(
-                'repo_setup.get_hash.repo_setup_hash_info.http_get', mocked):
+                'repo_setup.get_hash.hash_info.http_get', mocked):
             with self.assertLogs() as captured:
                 self.assertRaises(
-                    exc.TripleOHashInvalidDLRNResponse,
-                    thi.TripleOHashInfo,
+                    exc.HashInvalidDLRNResponse,
+                    thi.HashInfo,
                     'centos8',
                     'master',
                     'common',
-                    'current-tripleo',
+                    'current-podified',
                     {'dlrn_url': 'https://server.ok'},
                 )
             debug_msgs = [
@@ -222,6 +222,6 @@ class TestGetHashInfo(unittest.TestCase):
             error_str = (
                 "Invalid response received from the delorean server. Queried "
                 "URL: {0}. Response code: {1}. Response text: {2}. Failed to "
-                "create TripleOHashInfo object."
+                "create HashInfo object."
             ).format(bad_dlrn_url, '404', response_text_404)
             self.assertIn(error_str, debug_msgs)

--- a/tests/unit/repo_setup/test_main.py
+++ b/tests/unit/repo_setup/test_main.py
@@ -93,7 +93,7 @@ class TestTripleORepos(testtools.TestCase):
     @mock.patch('os.path.exists')
     def test_remove_existing(self, mock_exists, mock_remove, mock_listdir):
         fake_list = ['foo.repo', 'delorean.repo',
-                     'delorean-current-tripleo.repo',
+                     'delorean-current-podified.repo',
                      'repo-setup-centos-opstools.repo',
                      'repo-setup-centos-highavailability.repo']
         mock_exists.return_value = [True, False, True, False, True,
@@ -105,7 +105,7 @@ class TestTripleORepos(testtools.TestCase):
         self.assertIn(mock.call('/etc/yum.repos.d/delorean.repo'),
                       mock_remove.mock_calls)
         self.assertIn(mock.call('/etc/yum.repos.d/'
-                                'delorean-current-tripleo.repo'),
+                                'delorean-current-podified.repo'),
                       mock_remove.mock_calls)
         self.assertIn(
             mock.call('/etc/yum.repos.d/repo-setup-centos-opstools.repo'),
@@ -203,15 +203,15 @@ class TestTripleORepos(testtools.TestCase):
 
     @mock.patch('repo_setup.main._get_repo')
     @mock.patch('repo_setup.main._write_repo')
-    def test_install_repos_current_tripleo(self, mock_write, mock_get):
+    def test_install_repos_current_podified(self, mock_write, mock_get):
         args = mock.Mock()
-        args.repos = ['current-tripleo']
+        args.repos = ['current-podified']
         args.branch = 'master'
         args.output_path = 'test'
         args.distro = 'fake'
         mock_get.return_value = '[delorean]\nMr. Fusion'
         main._install_repos(args, 'roads/')
-        self.assertEqual([mock.call('roads/current-tripleo/delorean.repo',
+        self.assertEqual([mock.call('roads/current-podified/delorean.repo',
                                     args),
                           mock.call('roads/delorean-deps.repo', args),
                           ],
@@ -223,9 +223,9 @@ class TestTripleORepos(testtools.TestCase):
 
     @mock.patch('repo_setup.main._get_repo')
     @mock.patch('repo_setup.main._write_repo')
-    def test_install_repos_current_repo_setup_dev(self, mock_write, mock_get):
+    def test_install_repos_current_podified_dev(self, mock_write, mock_get):
         args = mock.Mock()
-        args.repos = ['current-repo-setup-dev']
+        args.repos = ['current-podified-dev']
         args.branch = 'master'
         args.output_path = 'test'
         args.distro = 'fake'
@@ -235,10 +235,10 @@ class TestTripleORepos(testtools.TestCase):
         # This is the wrong name for the deps repo, but I'm not bothered
         # enough by that to mess with mocking multiple different calls.
         mock_write.assert_any_call('[delorean]\nMr. Fusion', 'test')
-        mock_get.assert_any_call('roads/current-tripleo/delorean.repo', args)
-        mock_write.assert_any_call('[delorean-current-tripleo]\n'
+        mock_get.assert_any_call('roads/current-podified/delorean.repo', args)
+        mock_write.assert_any_call('[delorean-current-podified]\n'
                                    'priority=20\nMr. Fusion', 'test',
-                                   name='delorean-current-tripleo')
+                                   name='delorean-current-podified')
         mock_get.assert_called_with('roads/current/delorean.repo', args)
         mock_write.assert_called_with('[delorean]\npriority=10\n%s\n'
                                       'Mr. Fusion' %
@@ -247,15 +247,15 @@ class TestTripleORepos(testtools.TestCase):
 
     @mock.patch('repo_setup.main._get_repo')
     @mock.patch('repo_setup.main._write_repo')
-    def test_install_repos_repo_setup_ci_testing(self, mock_write, mock_get):
+    def test_install_repos_podified_ci_testing(self, mock_write, mock_get):
         args = mock.Mock()
-        args.repos = ['repo-setup-ci-testing']
+        args.repos = ['podified-ci-testing']
         args.branch = 'master'
         args.output_path = 'test'
         args.distro = 'fake'
         mock_get.return_value = '[delorean]\nMr. Fusion'
         main._install_repos(args, 'roads/')
-        self.assertEqual([mock.call('roads/repo-setup-ci-testing/delorean.repo',
+        self.assertEqual([mock.call('roads/podified-ci-testing/delorean.repo',
                                     args),
                           mock.call('roads/delorean-deps.repo', args),
                           ],
@@ -267,15 +267,15 @@ class TestTripleORepos(testtools.TestCase):
 
     @mock.patch('repo_setup.main._get_repo')
     @mock.patch('repo_setup.main._write_repo')
-    def test_install_repos_current_repo_setup_rdo(self, mock_write, mock_get):
+    def test_install_repos_current_podified_rdo(self, mock_write, mock_get):
         args = mock.Mock()
-        args.repos = ['current-repo-setup-rdo']
+        args.repos = ['current-podified-rdo']
         args.branch = 'master'
         args.output_path = 'test'
         args.distro = 'fake'
         mock_get.return_value = '[delorean]\nMr. Fusion'
         main._install_repos(args, 'roads/')
-        self.assertEqual([mock.call('roads/current-repo-setup-rdo/delorean.repo',
+        self.assertEqual([mock.call('roads/current-podified-rdo/delorean.repo',
                                     args),
                           mock.call('roads/delorean-deps.repo', args),
                           ],
@@ -348,7 +348,7 @@ class TestTripleORepos(testtools.TestCase):
         args.rdo_mirror = 'http://bar'
         # Abbreviated repos to verify the regex works
         fake_repo = '''
-[delorean-current-tripleo]
+[delorean-current-podified]
 name=test repo
 baseurl=https://trunk.rdoproject.org/centos7/some-repo-hash
 enabled=1
@@ -359,7 +359,7 @@ baseurl=http://mirror.centos.org/centos/7/virt/$basearch/kvm-common
 enabled=1
 '''
         expected_repo = '''
-[delorean-current-tripleo]
+[delorean-current-podified]
 name=test repo
 baseurl=http://bar/centos7/some-repo-hash
 enabled=1
@@ -708,41 +708,41 @@ class TestValidate(testtools.TestCase):
     def test_good(self):
         main._validate_args(self.args, '', '')
 
-    def test_current_and_repo_setup_dev(self):
-        self.args.repos = ['current', 'current-repo-setup-dev']
+    def test_current_and_podified_dev(self):
+        self.args.repos = ['current', 'current-podified-dev']
         self.assertRaises(main.InvalidArguments, main._validate_args,
                           self.args, '', '')
 
-    def test_repo_setup_ci_testing_and_current_tripleo(self):
-        self.args.repos = ['current-tripleo', 'repo-setup-ci-testing']
+    def test_podified_ci_testing_and_current_podified(self):
+        self.args.repos = ['current-podified', 'podified-ci-testing']
         self.assertRaises(main.InvalidArguments, main._validate_args,
                           self.args, '', '')
 
-    def test_repo_setup_ci_testing_and_ceph_opstools_allowed(self):
-        self.args.repos = ['ceph', 'opstools', 'repo-setup-ci-testing']
+    def test_podified_ci_testing_and_ceph_opstools_allowed(self):
+        self.args.repos = ['ceph', 'opstools', 'podified-ci-testing']
         main._validate_args(self.args, '', '')
 
-    def test_repo_setup_ci_testing_and_deps_allowed(self):
-        self.args.repos = ['deps', 'repo-setup-ci-testing']
+    def test_podified_ci_testing_and_deps_allowed(self):
+        self.args.repos = ['deps', 'podified-ci-testing']
         main._validate_args(self.args, '', '')
 
-    def test_ceph_and_repo_setup_dev(self):
-        self.args.repos = ['current-repo-setup-dev', 'ceph']
+    def test_ceph_and_podified_dev(self):
+        self.args.repos = ['current-podified-dev', 'ceph']
         self.args.output_path = main.DEFAULT_OUTPUT_PATH
         main._validate_args(self.args, '', '')
 
-    def test_deps_and_repo_setup_dev(self):
-        self.args.repos = ['deps', 'current-repo-setup-dev']
+    def test_deps_and_podified_dev(self):
+        self.args.repos = ['deps', 'current-podified-dev']
         self.assertRaises(main.InvalidArguments, main._validate_args,
                           self.args, '', '')
 
     def test_current_and_tripleo(self):
-        self.args.repos = ['current', 'current-tripleo']
+        self.args.repos = ['current', 'current-podified']
         self.assertRaises(main.InvalidArguments, main._validate_args,
                           self.args, '', '')
 
-    def test_deps_and_repo_setup_allowed(self):
-        self.args.repos = ['deps', 'current-tripleo']
+    def test_deps_and_podified_allowed(self):
+        self.args.repos = ['deps', 'current-podified']
         main._validate_args(self.args, '', '')
 
     def test_invalid_distro(self):
@@ -766,8 +766,8 @@ class TestValidate(testtools.TestCase):
     def test_validate_distro_repos(self):
         self.assertTrue(main._validate_distro_repos(self.args))
 
-    def test_validate_distro_repos_fedora_repo_setup_dev(self):
+    def test_validate_distro_repos_fedora_podified_dev(self):
         self.args.distro = 'fedora'
-        self.args.repos = ['current-repo-setup-dev']
+        self.args.repos = ['current-podified-dev']
         self.assertRaises(main.InvalidArguments, main._validate_distro_repos,
                           self.args)

--- a/tests/unit/yum_config/test_yum_config.py
+++ b/tests/unit/yum_config/test_yum_config.py
@@ -37,8 +37,8 @@ class TestYumConfig(test_main.TestYumConfigBase):
         self.mock_object(os, 'access')
         self.mock_object(os.path, 'isdir')
         return yum_cfg.YumConfig(dir_path=dir_path,
-                                        valid_options=valid_options,
-                                        file_extension=file_extension)
+                                 valid_options=valid_options,
+                                 file_extension=file_extension)
 
     def test_repo_setup_yum_config_invalid_dir_path(self):
         self.mock_object(os.path, 'isdir',

--- a/tox.ini
+++ b/tox.ini
@@ -68,7 +68,7 @@ commands =
   # Ensure that ansible is able to load the modules, as syntax check will fail
   # if modules cannot be loaded.
   sh -c "ansible-playbook --syntax-check  playbooks/*.yaml"
-  ansible localhost -m repo_setup.repos.get_hash -a "release=master os_version=centos8"
+  ansible localhost -m repo_setup.repos.get_hash -a "release=master os_version=centos9"
 
 allowlist_externals =
   sh
@@ -93,6 +93,6 @@ commands =
   molecule test
 
 [flake8]
-ignore = H803
+ignore = E501,W503,H803
 show-source = True
 exclude = .tox,dist,doc,*.egg,build


### PR DESCRIPTION
This introduces some basic tox jobs to run tox jobs for pep8, packaging and unit tests.

This also fixes some unit test failure/lint failure detected during enabling these jobs.