### PR TITLE
Exclude latest gnupg2 & Pin to last good version

### DIFF
--- a/plugins/module_utils/repo_setup/main.py
+++ b/plugins/module_utils/repo_setup/main.py
@@ -109,6 +109,7 @@ name=repo-setup-centos-baseos
 baseurl=%(mirror)s/%(legacy_url)s%(stream)s/BaseOS/$basearch/os/
 gpgcheck=0
 enabled=1
+exclude=gnupg2-2.3.3-3.el9.x86_64
 """
 
 

--- a/tests/unit/repo_setup/test_main.py
+++ b/tests/unit/repo_setup/test_main.py
@@ -492,7 +492,8 @@ enabled=1
                               '\n[repo-setup-centos-baseos]\n'
                               'name=repo-setup-centos-baseos\n'
                               'baseurl=mirror/9-stream/BaseOS'
-                              '/$basearch/os/\ngpgcheck=0\nenabled=1\n'),
+                              '/$basearch/os/\ngpgcheck=0\nenabled=1\n'
+                              'exclude=gnupg2-2.3.3-3.el9.x86_64\n'),
                               'test')
                           ],
                          mock_write.mock_calls)


### PR DESCRIPTION
This adds exclude for gnupg2-2.3.3-3.el9 and downgrade to last good version gnupg2.x86_64 2.3.3-2.el9 in centos9.

It will fix the following issue:
```
Source image rejected: None of the signatures were accepted,
reasons: No public keys imported
```
Related-Bug: https://bugs.launchpad.net/tripleo/+bug/2015309