### PR TITLE
Revert "Exclude latest gnupg2 & Pin to last good version"

### DIFF
--- a/plugins/module_utils/repo_setup/main.py
+++ b/plugins/module_utils/repo_setup/main.py
@@ -109,7 +109,6 @@ name=repo-setup-centos-baseos
 baseurl=%(mirror)s/%(legacy_url)s%(stream)s/BaseOS/$basearch/os/
 gpgcheck=0
 enabled=1
-exclude=gnupg2-2.3.3-3.el9.x86_64
 """
 
 

--- a/tests/unit/repo_setup/test_main.py
+++ b/tests/unit/repo_setup/test_main.py
@@ -492,8 +492,7 @@ enabled=1
                               '\n[repo-setup-centos-baseos]\n'
                               'name=repo-setup-centos-baseos\n'
                               'baseurl=mirror/9-stream/BaseOS'
-                              '/$basearch/os/\ngpgcheck=0\nenabled=1\n'
-                              'exclude=gnupg2-2.3.3-3.el9.x86_64\n'),
+                              '/$basearch/os/\ngpgcheck=0\nenabled=1\n'),
                               'test')
                           ],
                          mock_write.mock_calls)


### PR DESCRIPTION
https://mirror.stream.centos.org/9-stream/BaseOS/source/tree/Packages/gnupg2-2.3.3-3.el9.src.rpm infected rpm is removed from the mirror.

This patch removes the workaround.