### PR TITLE
[get_hash] Add support for returning dlrn_api_url

### DIFF
--- a/plugins/module_utils/repo_setup/get_hash/__main__.py
+++ b/plugins/module_utils/repo_setup/get_hash/__main__.py
@@ -101,6 +101,7 @@ def main():
                      "full_hash": repo_setup_hash_info.full_hash,
                      "extended_hash": repo_setup_hash_info.extended_hash,
                      "dlrn_url": repo_setup_hash_info.dlrn_url,
+                     "dlrn_api_url": repo_setup_hash_info.dlrn_api_url,
                      "os_version": repo_setup_hash_info.os_version,
                      "release": repo_setup_hash_info.release,
                      "component": repo_setup_hash_info.component,

--- a/plugins/module_utils/repo_setup/get_hash/hash_info.py
+++ b/plugins/module_utils/repo_setup/get_hash/hash_info.py
@@ -138,6 +138,7 @@ class HashInfo:
 
         repo_url = self._resolve_repo_url(config["dlrn_url"])
         self.dlrn_url = repo_url
+        self.dlrn_api_url = self._get_dlrn_api_url(config["dlrn_url"])
 
         repo_url_response, status = http_get(repo_url)
 
@@ -200,6 +201,20 @@ class HashInfo:
             )
         logging.debug("repo_url is %s", repo_url)
         return repo_url
+
+    def _get_dlrn_api_url(self, dlrn_url):
+        """
+        Returns the DLRN API url
+        Here is the format of DLRN API url:
+            * antelope: https://trunk.rdoproject.org/api-centos9-antelope
+            * master: https://trunk.rdoproject.org/api-centos9-master-uc
+        """
+        dlrn_api_url = "%s/api-%s-%s" % (dlrn_url, self.os_version, self.release)
+
+        if self.release == "master":
+            dlrn_api_url = "%s-uc" % dlrn_api_url
+        logging.debug("dlrn_api_url is %s", dlrn_api_url)
+        return dlrn_api_url
 
     def _hashes_from_commit_yaml(self, delorean_result):
         """This function is used when a commit.yaml file is returned

--- a/plugins/modules/get_hash.py
+++ b/plugins/modules/get_hash.py
@@ -83,6 +83,11 @@ dlrn_url:
     type: str
     returned: always
     sample: 'https://trunk.rdoproject.org/centos8-master/current-podified/delorean.repo.md5'  # noqa E501
+dlrn_api_url:
+    description: The dlrn API server url for further interaction with dlrn server.
+    type: str
+    returned: always
+    sample: 'https://trunk.rdoproject.org/api-centos-master-uc'  # noqa E501
 """
 
 from ansible.module_utils.basic import AnsibleModule  # noqa: E402
@@ -126,6 +131,7 @@ def run_module():
         result["full_hash"] = hash_result.full_hash
         result["extended_hash"] = hash_result.extended_hash
         result["dlrn_url"] = hash_result.dlrn_url
+        result["dlrn_api_url"] = hash_result.dlrn_api_url
         result["success"] = True
     except Exception as exc:
         result["error"] = str(exc)


### PR DESCRIPTION
This patch adds the support of returning dlrn_api_url which can be later used with dlrnapi client for job status reporting.