### PR TITLE
Add support for dlrn_hash_tag

### DIFF
--- a/plugins/module_utils/repo_setup/get_hash/__main__.py
+++ b/plugins/module_utils/repo_setup/get_hash/__main__.py
@@ -66,6 +66,11 @@ def main():
         action="store_true",
         help=("Enable JSON output"),
     )
+    parser.add_argument(
+        "--dlrn-hash-tag",
+        default=None,
+        help=("Pass a particular dlrn hash tag"),
+    )
 
     args = parser.parse_args()
 
@@ -86,6 +91,7 @@ def main():
         args.release,
         args.component,
         args.tag,
+        args.dlrn_hash_tag,
         config,
     )
     if args.json:

--- a/plugins/module_utils/repo_setup/get_hash/hash_info.py
+++ b/plugins/module_utils/repo_setup/get_hash/hash_info.py
@@ -120,7 +120,7 @@ class HashInfo:
                 result_config[k] = loaded_config[k]
         return result_config
 
-    def __init__(self, os_version, release, component, tag, config=None):
+    def __init__(self, os_version, release, component, tag, dlrn_hash_tag=None, config=None):
         """Create a new HashInfo object
 
         :param os_version: The OS and version e.g. centos8
@@ -135,6 +135,7 @@ class HashInfo:
         self.release = release
         self.component = component
         self.tag = tag
+        self.dlrn_hash_tag = dlrn_hash_tag
 
         repo_url = self._resolve_repo_url(config["dlrn_url"])
         self.dlrn_url = repo_url
@@ -191,6 +192,19 @@ class HashInfo:
                 self.release,
                 self.tag,
             )
+
+        # Fix the repo_url for dlrn_hash_tag
+        if self.dlrn_hash_tag:
+            for _context in ['delorean.repo.md5', 'commit.yaml']:
+                if repo_url.endswith(_context):
+                    _hash = self.dlrn_hash_tag
+                    _data = repo_url.split(_context)
+                    repo_url = '{}{}/{}/{}/{}'.format(_data[0],
+                                                      str(_hash[:2]),
+                                                      str(_hash[2:4]),
+                                                      str(_hash),
+                                                      _context)
+
         logging.debug("repo_url is %s", repo_url)
         return repo_url
 

--- a/plugins/modules/get_hash.py
+++ b/plugins/modules/get_hash.py
@@ -43,6 +43,12 @@ options:
         required: false
         type: str
         default: https://trunk.rdoproject.org
+    dlrn_hash_tag:
+        description: The DLRN hash to get queries about
+        required: false
+        type: str
+        default: None
+
 
 author:
     - Marios Andreou (@marios)
@@ -108,6 +114,8 @@ def run_module():
         dlrn_url=dict(
             type="str", required=False, default="https://trunk.rdoproject.org"
         ),
+        dlrn_hash_tag=dict(type="str", required=False, default=None),
+
     )
 
     module = AnsibleModule(argument_spec, supports_check_mode=False)

--- a/tests/unit/get_hash/test_get_hash_info.py
+++ b/tests/unit/get_hash/test_get_hash_info.py
@@ -45,7 +45,7 @@ class TestGetHashInfo(unittest.TestCase):
         with patch(
                 'repo_setup.get_hash.hash_info.http_get', mocked):
             mock_hash_info = thi.HashInfo(
-                'centos8', 'master', 'common', 'current-podified'
+                'centos8', 'master', 'common', 'current-podified', None
             )
             actual_result = mock_hash_info._hashes_from_commit_yaml(
                 sample_commit_yaml
@@ -58,7 +58,7 @@ class TestGetHashInfo(unittest.TestCase):
         with patch(
                 'repo_setup.get_hash.hash_info.http_get', mocked):
             c8_component_hash_info = thi.HashInfo(
-                'centos8', 'master', 'common', 'current-podified'
+                'centos8', 'master', 'common', 'current-podified', None
             )
             repo_url = c8_component_hash_info._resolve_repo_url("https://woo")
             self.assertEqual(
@@ -72,7 +72,7 @@ class TestGetHashInfo(unittest.TestCase):
         with patch(
                 'repo_setup.get_hash.hash_info.http_get', mocked):
             c8_hash_info = thi.HashInfo(
-                'centos8', 'master', None, 'current-podified'
+                'centos8', 'master', None, 'current-podified', None
             )
             repo_url = c8_hash_info._resolve_repo_url("https://woo")
             self.assertEqual(
@@ -86,7 +86,7 @@ class TestGetHashInfo(unittest.TestCase):
         with patch(
                 'repo_setup.get_hash.hash_info.http_get', mocked):
             created_hash_info = thi.HashInfo(
-                'centos8', 'master', None, 'current-podified'
+                'centos8', 'master', None, 'current-podified', None
             )
             self.assertIsInstance(created_hash_info, thi.HashInfo)
             self.assertEqual(
@@ -105,7 +105,7 @@ class TestGetHashInfo(unittest.TestCase):
         with patch(
                 'repo_setup.get_hash.hash_info.http_get', mocked):
             created_hash_info = thi.HashInfo(
-                'centos8', 'victoria', 'common', 'podified-ci-testing'
+                'centos8', 'victoria', 'common', 'podified-ci-testing', None
             )
             self.assertIsInstance(created_hash_info, thi.HashInfo)
             self.assertEqual(created_hash_info.full_hash, expected_full_hash)
@@ -126,7 +126,7 @@ class TestGetHashInfo(unittest.TestCase):
         with patch(
                 'repo_setup.get_hash.hash_info.http_get', mocked):
             mock_hash_info = thi.HashInfo(
-                'centos8', 'master', 'common', 'current-podified',
+                'centos8', 'master', 'common', 'current-podified', None,
                 {'dlrn_url': 'https://foo.bar.baz'}
             )
             self.assertEqual(expected_dlrn_url, mock_hash_info.dlrn_url)
@@ -138,7 +138,7 @@ class TestGetHashInfo(unittest.TestCase):
         with patch(
                 'repo_setup.get_hash.hash_info.http_get', mocked):
             mock_hash_info = thi.HashInfo(
-                'centos8', 'master', 'common', 'current-podified',
+                'centos8', 'master', 'common', 'current-podified', None,
                 {'dlrn_url': ''}
             )
             self.assertEqual(expected_dlrn_url, mock_hash_info.dlrn_url)
@@ -158,6 +158,7 @@ class TestGetHashInfo(unittest.TestCase):
                     'master',
                     'common',
                     'current-podified',
+                    None,
                     {'dlrn_url': 'https://server.ok'},
                 )
             debug_msgs = [

--- a/tests/unit/repo_setup/test_main.py
+++ b/tests/unit/repo_setup/test_main.py
@@ -105,6 +105,7 @@ class TestTripleORepos(testtools.TestCase):
     def test_install_repos_current(self, mock_write, mock_get):
         args = mock.Mock()
         args.repos = ['current']
+        args.dlrn_hash_tag = None
         args.branch = 'master'
         args.output_path = 'test'
         args.distro = 'fake'
@@ -139,6 +140,7 @@ class TestTripleORepos(testtools.TestCase):
     def test_install_repos_current_podified(self, mock_write, mock_get):
         args = mock.Mock()
         args.repos = ['current-podified']
+        args.dlrn_hash_tag = None
         args.branch = 'master'
         args.output_path = 'test'
         args.distro = 'fake'
@@ -159,6 +161,7 @@ class TestTripleORepos(testtools.TestCase):
     def test_install_repos_podified_ci_testing(self, mock_write, mock_get):
         args = mock.Mock()
         args.repos = ['podified-ci-testing']
+        args.dlrn_hash_tag = None
         args.branch = 'master'
         args.output_path = 'test'
         args.distro = 'fake'
@@ -207,6 +210,7 @@ class TestTripleORepos(testtools.TestCase):
     def test_install_repos_centos8(self, mock_write, mock_get):
         args = mock.Mock()
         args.repos = ['current']
+        args.dlrn_hash_tag = None
         args.branch = 'master'
         args.output_path = 'test'
         args.distro = 'centos8'
@@ -247,6 +251,7 @@ class TestTripleORepos(testtools.TestCase):
         args.stream = True
         args.no_stream = False
         args.mirror = 'mirror'
+        args.dlrn_hash_tag = None
         mock_get.return_value = '[delorean]\nMr. Fusion'
         main._install_repos(args, 'roads/')
         self.assertEqual([mock.call('roads/current/delorean.repo', args),
@@ -276,6 +281,7 @@ class TestTripleORepos(testtools.TestCase):
     def test_install_repos_centos9_stream(self, mock_write, mock_get):
         args = mock.Mock()
         args.repos = ['current']
+        args.dlrn_hash_tag = None
         args.branch = 'master'
         args.output_path = 'test'
         args.distro = 'centos9'
@@ -323,6 +329,7 @@ class TestTripleORepos(testtools.TestCase):
     def test_install_repos_centos8_no_stream(self, mock_write, mock_get):
         args = mock.Mock()
         args.repos = ['current']
+        args.dlrn_hash_tag = None
         args.branch = 'master'
         args.output_path = 'test'
         args.distro = 'centos8'


### PR DESCRIPTION
This pr adds the support of --dlrn-hash-tag to repo-setup and repo-setup-get-hash tools. By using --dlrn-hash-tag, we can generate dlrn repos for a particular hash. It will be useful for re-running the job and reporting it to dlrn.

Below are the commands on how to use it:
```
repo-setup current --dlrn-hash-tag b6e71147e9ec7234501c50f94860c58d -d centos9 -b antelope -o /tmp/repos/
```
and
```
repo-setup-get-hash --os-version centos9 --tag current --release antelope --dlrn-hash-tag 60c7405a7f2ab5ecab0cc8b4ed18711c
```