### PR TITLE
Pin setuptools<71.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
+setuptools<71.0.0
 pbr!=2.1.0,>=2.0.0 # Apache-2.0
 requests>=2.10.0 # Apache-2.0
 PyYAML>=3.12 # MIT


### PR DESCRIPTION
Recent release of setuptools broke the repo-setup installation with following error:
```
2024-07-17 20:31:13.693044 | controller |       opt = self.warn_dash_deprecation(opt, section)
2024-07-17 20:31:13.693058 | controller |     Traceback (most recent call last):
2024-07-17 20:31:13.693072 | controller |       File "/home/zuul/ci-framework-data/tmp/repo-setup/setup.py", line 19, in <module>
2024-07-17 20:31:13.693086 | controller |         setuptools.setup(
2024-07-17 20:31:13.693100 | controller |       File "/home/zuul/ci-framework-data/venv/lib64/python3.9/site-packages/setuptools/__init__.py", line 106, in setup
2024-07-17 20:31:13.693113 | controller |         return distutils.core.setup(**attrs)
2024-07-17 20:31:13.693127 | controller |       File "/home/zuul/ci-framework-data/venv/lib64/python3.9/site-packages/setuptools/_distutils/core.py", line 184, in setup
2024-07-17 20:31:13.693169 | controller |         return run_commands(dist)
2024-07-17 20:31:13.693197 | controller |       File "/home/zuul/ci-framework-data/venv/lib64/python3.9/site-packages/setuptools/_distutils/core.py", line 200, in run_commands
2024-07-17 20:31:13.693212 | controller |         dist.run_commands()
2024-07-17 20:31:13.693226 | controller |       File "/home/zuul/ci-framework-data/venv/lib64/python3.9/site-packages/setuptools/_distutils/dist.py", line 970, in run_commands
2024-07-17 20:31:13.693240 | controller |         self.run_command(cmd)
2024-07-17 20:31:13.693253 | controller |       File "/home/zuul/ci-framework-data/venv/lib64/python3.9/site-packages/setuptools/dist.py", line 974, in run_command
2024-07-17 20:31:13.693267 | controller |         super().run_command(command)
2024-07-17 20:31:13.693289 | controller |       File "/home/zuul/ci-framework-data/venv/lib64/python3.9/site-packages/setuptools/_distutils/dist.py", line 988, in run_command
2024-07-17 20:31:13.694165 | controller |         cmd_obj.ensure_finalized()
2024-07-17 20:31:13.694198 | controller |       File "/home/zuul/ci-framework-data/venv/lib64/python3.9/site-packages/setuptools/_distutils/cmd.py", line 111, in ensure_finalized
2024-07-17 20:31:13.694214 | controller |         self.finalize_options()
2024-07-17 20:31:13.694227 | controller |       File "/home/zuul/ci-framework-data/venv/lib64/python3.9/site-packages/setuptools/command/install.py", line 57, in finalize_options
2024-07-17 20:31:13.694241 | controller |         super().finalize_options()
2024-07-17 20:31:13.694255 | controller |       File "/home/zuul/ci-framework-data/venv/lib64/python3.9/site-packages/setuptools/_distutils/command/install.py", line 407, in finalize_options
2024-07-17 20:31:13.694273 | controller |         'dist_fullname': self.distribution.get_fullname(),
2024-07-17 20:31:13.694287 | controller |       File "/home/zuul/ci-framework-data/venv/lib64/python3.9/site-packages/setuptools/_core_metadata.py", line 266, in get_fullname
2024-07-17 20:31:13.694301 | controller |         return _distribution_fullname(self.get_name(), self.get_version())
2024-07-17 20:31:13.694317 | controller |       File "/home/zuul/ci-framework-data/venv/lib64/python3.9/site-packages/setuptools/_core_metadata.py", line 284, in _distribution_fullname
2024-07-17 20:31:13.694331 | controller |         canonicalize_version(version, strip_trailing_zero=False),
2024-07-17 20:31:13.694345 | controller |     TypeError: canonicalize_version() got an unexpected keyword argument 'strip_trailing_zero'
2024-07-17 20:31:13.694359 | controller |   stderr_lines: <omitted>
2024-07-17 20:31:13.694372 | controller |   stdout: |-
2024-07-17 20:31:13.694386 | controller |     [pbr] Generating ChangeLog
2024-07-17 20:31:13.694400 | controller |     running install
2024-07-17 20:31:13.694414 | controller |   stdout_lines: <omitted>
```

Downgrading setuptools fixes the issue.