### PR TITLE
Add optimize component in repo_setup

### DIFF
--- a/plugins/module_utils/repo_setup/get_hash/config.yaml
+++ b/plugins/module_utils/repo_setup/get_hash/config.yaml
@@ -23,6 +23,7 @@ repo_setup_ci_components:
   - manila
   - network
   - octavia
+  - optimize
   - swift
   - tempest
   - podified


### PR DESCRIPTION
https://review.rdoproject.org/r/c/rdoinfo/+/55312 Create new component optimize for watcher service. In order to use repo_setup for optimize component, we need to add optimize component to get_hash. Then repo_setup will return process hashes from dlrn[1].

[1]. https://trunk.rdoproject.org/centos9-antelope/component/optimize/