### PR TITLE
Add openstack-approvers to approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,9 +3,17 @@ approvers:
 - frenzyfriday
 - lewisdenny
 - pablintino
+- abays
+- dprince
+- olliewalsh
+- stuggi
 options: {}
 reviewers:
 - bshewale
 - frenzyfriday
 - lewisdenny
 - pablintino
+- abays
+- dprince
+- olliewalsh
+- stuggi


### PR DESCRIPTION
The source for ci-operator/config/openstack-k8s-operators/repo-setup/OWNERS in the the CI configuration at github.com/openshift/release is the OWNERS of this repo.
To update the CI configuration for e.g. feature branching, the openstack-approvers should be in the OWNERS
like for in the other repositories.