### PR TITLE
Add support for epoxy in repo-setup

### DIFF
--- a/plugins/module_utils/repo_setup/get_hash/config.yaml
+++ b/plugins/module_utils/repo_setup/get_hash/config.yaml
@@ -7,6 +7,7 @@ dlrn_url: 'https://trunk.rdoproject.org'
 repo_setup_releases:
   - master
   - antelope
+  - epoxy
   - osp18
 
 repo_setup_ci_components:

--- a/plugins/module_utils/repo_setup/get_hash/constants.py
+++ b/plugins/module_utils/repo_setup/get_hash/constants.py
@@ -41,6 +41,7 @@ DEFAULT_CONFIG = {
     "repo_setup_releases": [
         "master",
         "antelope",
+        "epoxy",
         "osp18",
     ],
     "dlrn_url": "https://trunk.rdoproject.org",


### PR DESCRIPTION
Below are the cli results:
repo-setup
```
repo-setup on  epoxy [!] via 🐍 v3.13.3
❯ repo-setup current -b epoxy -d centos9 -o /tmp/repos/
WARNING: Unsupported platform 'fedora42' detected by repo-setup, centos9 will be used unless you use CLI param to change it.
Installed repo delorean to /tmp/repos/delorean.repo
Installed repo delorean-epoxy-testing to /tmp/repos/delorean-epoxy-testing.repo
Installed repo repo-setup-centos-highavailability to /tmp/repos/repo-setup-centos-highavailability.repo
Installed repo repo-setup-centos-powertools to /tmp/repos/repo-setup-centos-powertools.repo
Installed repo repo-setup-centos-appstream to /tmp/repos/repo-setup-centos-appstream.repo
Installed repo repo-setup-centos-baseos to /tmp/repos/repo-setup-centos-baseos.repo
Cache directory "/home/chandankumar/.cache/libdnf5" does not exist. Nothing to clean.
```
repo-setup=get-hash
```
repo-setup on  epoxy [!] via 🐍 v3.13.3
❯ repo-setup-get-hash --os-version centos9 --tag current --release epoxy --json
{"commit_hash": null, "distro_hash": null, "full_hash": "6264cf4b7a47323f0a357bf24a0292e4", "extended_hash": null, "dlrn_url": "https://trunk.rdoproject.org/centos9-epoxy/current/delorean.repo.md5", "dlrn_api_url": "https://trunk.rdoproject.org/api-centos9-epoxy", "os_version": "centos9", "release": "epoxy", "component": null, "tag": "current"}
```

It is needed to build epoxy containers via content provider.

Jira: [OSPRH-16312](https://issues.redhat.com//browse/OSPRH-16312)