### PR TITLE
Add podified-ci-testing-tcib repo

### DIFF
--- a/plugins/module_utils/repo_setup/get_hash/config.yaml
+++ b/plugins/module_utils/repo_setup/get_hash/config.yaml
@@ -37,6 +37,7 @@ rdo_named_tags:
   - component-ci-testing
   - promoted-components
   - podified-ci-testing
+  - podified-ci-testing-tcib
   - current-podified
 
 os_versions:

--- a/plugins/module_utils/repo_setup/get_hash/constants.py
+++ b/plugins/module_utils/repo_setup/get_hash/constants.py
@@ -51,6 +51,7 @@ DEFAULT_CONFIG = {
         "component-ci-testing",
         "promoted-components",
         "podified-ci-testing",
+        "podified-ci-testing-tcib",
         "current-podified",
         "current-podified-rdo",
     ],

--- a/plugins/module_utils/repo_setup/main.py
+++ b/plugins/module_utils/repo_setup/main.py
@@ -186,6 +186,7 @@ def _parse_args(distro_id, distro_major_version_id):
             "current-podified-dev",
             "ceph",
             "podified-ci-testing",
+            "podified-ci-testing-tcib",
             "current-podified-rdo",
         ],
         help="A list of repos.  Available repos: "
@@ -301,6 +302,7 @@ def _validate_distro_repos(args):
             "ceph",
             "deps",
             "podified-ci-testing",
+            "podified-ci-testing-tcib",
         ]
     elif args.distro in DISTRO_CHOICES:
         valid_repos = [
@@ -310,6 +312,7 @@ def _validate_distro_repos(args):
             "current-podified",
             "deps",
             "podified-ci-testing",
+            "podified-ci-testing-tcib",
         ]
     invalid_repos = [x for x in args.repos if x not in valid_repos]
     if len(invalid_repos) > 0:
@@ -354,6 +357,15 @@ def _validate_podified_ci_testing(repos):
         else:
             raise InvalidArguments(
                 "Cannot use podified-ci-testing at the "
+                "same time as other repos, except "
+                "deps|ceph."
+            )
+    if "podified-ci-testing-tcib" in repos and len(repos) > 1:
+        if "deps" in repos or "ceph" in repos:
+            return True
+        else:
+            raise InvalidArguments(
+                "Cannot use podified-ci-testing-tcib at the "
                 "same time as other repos, except "
                 "deps|ceph."
             )
@@ -549,6 +561,10 @@ def _install_repos(args, base_path):
             install_deps(args, base_path)
         elif repo == "podified-ci-testing":
             content = _get_repo(base_path + _get_dlrn_hash_tag(args, "podified-ci-testing/delorean.repo"), args)
+            _write_repo(content, args.output_path)
+            install_deps(args, base_path)
+        elif repo == "podified-ci-testing-tcib":
+            content = _get_repo(base_path + _get_dlrn_hash_tag(args, "podified-ci-testing-tcib/delorean.repo"), args)
             _write_repo(content, args.output_path)
             install_deps(args, base_path)
         elif repo == "ceph":

--- a/tests/unit/repo_setup/test_main.py
+++ b/tests/unit/repo_setup/test_main.py
@@ -529,8 +529,17 @@ class TestValidate(testtools.TestCase):
         self.assertRaises(main.InvalidArguments, main._validate_args,
                           self.args, '', '')
 
+    def test_podified_ci_testing_tmp_and_current_podified(self):
+        self.args.repos = ['current-podified', 'podified-ci-testing-tcib']
+        self.assertRaises(main.InvalidArguments, main._validate_args,
+                          self.args, '', '')
+
     def test_podified_ci_testing_and_deps_allowed(self):
         self.args.repos = ['deps', 'podified-ci-testing']
+        main._validate_args(self.args, '', '')
+
+    def test_podified_ci_testing_tmp_and_deps_allowed(self):
+        self.args.repos = ['deps', 'podified-ci-testing-tcib']
         main._validate_args(self.args, '', '')
 
     def test_deps_and_podified_dev(self):


### PR DESCRIPTION
This DRLN tag would be used just for building the containers, so the `podified-ci-testing` then will be only updated after we ensure we can properly build the containers. The reason for this is that we have a lot of jobs that expect to find container tag for `podified-ci-testing` already in repository, while the containers may never be pushed due to tcib issues. The intermediate tag would allow us to bypass this without redesigning all existing jobs.