### PR TITLE
Add support for legacy TripleO repo names

### DIFF
--- a/plugins/module_utils/repo_setup/get_hash/constants.py
+++ b/plugins/module_utils/repo_setup/get_hash/constants.py
@@ -54,6 +54,8 @@ DEFAULT_CONFIG = {
         "podified-ci-testing-tcib",
         "current-podified",
         "current-podified-rdo",
+        "tripleo-ci-testing",
+        "current-tripleo",
     ],
     "repo_setup_ci_components": [
         "baremetal",


### PR DESCRIPTION
Add tripleo-ci-testing and current-tripleo to the list of allowed rdo_named_tags. These are needed for RHOS 16.2 and 17.1 promotion jobs which use the legacy TripleO promotion workflow.

This enables the repo-setup tool to work with both modern podified deployments and legacy TripleO deployments without requiring separate tools or custom workarounds.

Related: [OSPNW-1343](https://issues.redhat.com//browse/OSPNW-1343)