### PR TITLE
Revert "Add support for legacy TripleO repo names"

### DIFF
--- a/plugins/module_utils/repo_setup/get_hash/constants.py
+++ b/plugins/module_utils/repo_setup/get_hash/constants.py
@@ -54,8 +54,6 @@ DEFAULT_CONFIG = {
         "podified-ci-testing-tcib",
         "current-podified",
         "current-podified-rdo",
-        "tripleo-ci-testing",
-        "current-tripleo",
     ],
     "repo_setup_ci_components": [
         "baremetal",


### PR DESCRIPTION
This reverts commit fcf69b2bc4bbf84adf3f71ebbe173382294a6f03.
The override approach using `cifmw_repo_setup_src` is now working correctly for RHOS 16.2/17.1 jobs, so we don't need to add tripleo-ci-testing and current-tripleo to the podified repo-setup.

This keeps the podified repo-setup focused on podified deployments only, and legacy RHOS releases will use the TripleO variant via variable override.

Related: [OSPNW-1343](https://issues.redhat.com//browse/OSPNW-1343)