### PR TITLE
Add --extra-repo and --disable-repo CLI options

### DIFF
--- a/plugins/module_utils/repo_setup/main.py
+++ b/plugins/module_utils/repo_setup/main.py
@@ -93,6 +93,13 @@ baseurl=%(mirror)s/%(legacy_url)s%(stream)s/BaseOS/$basearch/os/
 gpgcheck=0
 enabled=1
 """
+EXTRA_REPO_TEMPLATE = """
+[repo-setup-%(name)s]
+name=repo-setup-%(name)s
+baseurl=%(baseurl)s
+gpgcheck=%(gpgcheck)s
+%(gpgkey_line)senabled=1
+"""
 
 
 # unversioned fedora added for backwards compatibility
@@ -233,6 +240,31 @@ def _parse_args(distro_id, distro_major_version_id):
     parser.add_argument(
         "--dlrn-hash-tag",
         help="Generate DLRN repos using specific dlrn tag",
+    )
+    parser.add_argument(
+        "--extra-repo",
+        metavar="NAME,baseurl=URL[,gpgkey=URL]",
+        action="append",
+        default=[],
+        help="Add an extra repo. Format: NAME,baseurl=URL[,gpgkey=URL]. "
+        "When gpgkey is provided, gpgcheck is enabled automatically. "
+        "Can be specified multiple times. "
+        "Example: --extra-repo extras-common,"
+        "baseurl=https://mirror.stream.centos.org/SIGs/9-stream/"
+        "extras/x86_64/extras-common/,"
+        "gpgkey=https://www.centos.org/keys/"
+        "RPM-GPG-KEY-CentOS-SIG-Extras",
+    )
+    parser.add_argument(
+        "--disable-repo",
+        metavar="REPO_NAME",
+        action="append",
+        default=[],
+        help="Disable a default repo by name. This prevents "
+        "the repo file from being created. Can be specified "
+        "multiple times. Valid names: highavailability, "
+        "powertools, appstream, baseos, ceph. "
+        "Example: --disable-repo powertools",
     )
     stream_group = parser.add_mutually_exclusive_group()
     stream_group.add_argument(
@@ -401,11 +433,55 @@ def _validate_distro_stream(args, distro_name, distro_major_version_id):
     return True
 
 
+def _parse_extra_repos(extra_repos):
+    """Parse --extra-repo arguments into a list of dicts.
+
+    Format: NAME,baseurl=URL[,gpgkey=URL]
+    """
+    parsed = []
+    for entry in extra_repos:
+        parts = entry.split(",")
+        if len(parts) < 2:
+            raise InvalidArguments(
+                "Invalid --extra-repo format '%s'. "
+                "Expected NAME,baseurl=URL[,gpgkey=URL]." % entry
+            )
+        name = parts[0].strip()
+        if not name:
+            raise InvalidArguments(
+                "Invalid --extra-repo format '%s'. "
+                "Repo name is required." % entry
+            )
+        repo = {"name": name, "baseurl": None, "gpgkey": None}
+        for part in parts[1:]:
+            if "=" not in part:
+                raise InvalidArguments(
+                    "Invalid --extra-repo option '%s' in '%s'. "
+                    "Expected key=value." % (part, entry)
+                )
+            key, value = part.split("=", 1)
+            key = key.strip()
+            if key not in ("baseurl", "gpgkey"):
+                raise InvalidArguments(
+                    "Invalid --extra-repo option '%s' in '%s'. "
+                    "Supported options: baseurl, gpgkey." % (key, entry)
+                )
+            repo[key] = value.strip()
+        if not repo["baseurl"]:
+            raise InvalidArguments(
+                "Invalid --extra-repo format '%s'. "
+                "baseurl is required." % entry
+            )
+        parsed.append(repo)
+    return parsed
+
+
 def _validate_args(args, distro_name, distro_major_version_id):
     _validate_current_repos(args.repos)
     _validate_distro_repos(args)
     _validate_podified_ci_testing(args.repos)
     _validate_distro_stream(args, distro_name, distro_major_version_id)
+    _parse_extra_repos(args.extra_repo)
 
 
 def _remove_existing(args):
@@ -535,6 +611,24 @@ def _get_dlrn_hash_tag(args, repo):
     return repo
 
 
+def _is_repo_disabled(args, repo_name):
+    """Check if a repo has been disabled via --disable-repo."""
+    return repo_name in args.disable_repo
+
+
+def _install_extra_repos(args):
+    """Install extra repos specified via --extra-repo."""
+    for extra in _parse_extra_repos(args.extra_repo):
+        gpgkey = extra.get("gpgkey")
+        content = EXTRA_REPO_TEMPLATE % {
+            "name": extra["name"],
+            "baseurl": extra["baseurl"],
+            "gpgcheck": "1" if gpgkey else "0",
+            "gpgkey_line": "gpgkey=%s\n" % gpgkey if gpgkey else "",
+        }
+        _write_repo(content, args.output_path)
+
+
 def _install_repos(args, base_path):
     def install_deps(args, base_path):
         if 'rhel' in args.distro:
@@ -568,8 +662,11 @@ def _install_repos(args, base_path):
             _write_repo(content, args.output_path)
             install_deps(args, base_path)
         elif repo == "ceph":
-            content = _create_ceph(args, "pacific")
-            _write_repo(content, args.output_path)
+            if not _is_repo_disabled(args, "ceph"):
+                content = _create_ceph(args, "pacific")
+                _write_repo(content, args.output_path)
+            else:
+                print("Skipping disabled repo: ceph")
         else:
             raise InvalidArguments('Invalid repo "%s" specified' % repo)
 
@@ -594,19 +691,25 @@ def _install_repos(args, base_path):
         # rhbz/1961558 and lpbz/1929634
         extra = ""
         distro_name = str(distro[-1]) + "-stream"
-        content = APPSTREAM_REPO_TEMPLATE % {
-            "mirror": args.mirror,
-            "extra": extra,
-            "legacy_url": legacy_url,
-            "stream": distro_name,
-        }
-        _write_repo(content, distro_path)
-        content = BASE_REPO_TEMPLATE % {
-            "mirror": args.mirror,
-            "legacy_url": legacy_url,
-            "stream": distro_name,
-        }
-        _write_repo(content, distro_path)
+        if not _is_repo_disabled(args, "appstream"):
+            content = APPSTREAM_REPO_TEMPLATE % {
+                "mirror": args.mirror,
+                "extra": extra,
+                "legacy_url": legacy_url,
+                "stream": distro_name,
+            }
+            _write_repo(content, distro_path)
+        else:
+            print("Skipping disabled repo: appstream")
+        if not _is_repo_disabled(args, "baseos"):
+            content = BASE_REPO_TEMPLATE % {
+                "mirror": args.mirror,
+                "legacy_url": legacy_url,
+                "stream": distro_name,
+            }
+            _write_repo(content, distro_path)
+        else:
+            print("Skipping disabled repo: baseos")
         if distro in ["centos8", "centos9", "centos-10", "ubi8", "ubi9"]:
             distro = "centos" + str(distro[-1])
 
@@ -622,36 +725,47 @@ def _install_repos(args, base_path):
                 legacy_url = ""
                 pt_name = "CRB"
 
-            content = HIGHAVAILABILITY_REPO_TEMPLATE % {
-                "mirror": args.mirror,
-                "stream": stream,
-                "legacy_url": legacy_url,
-            }
-            _write_repo(content, args.output_path)
+            if not _is_repo_disabled(args, "highavailability"):
+                content = HIGHAVAILABILITY_REPO_TEMPLATE % {
+                    "mirror": args.mirror,
+                    "stream": stream,
+                    "legacy_url": legacy_url,
+                }
+                _write_repo(content, args.output_path)
+            else:
+                print("Skipping disabled repo: highavailability")
 
-            content = POWERTOOLS_REPO_TEMPLATE % {
-                "mirror": args.mirror,
-                "stream": stream,
-                "legacy_url": legacy_url,
-                "pt_name": pt_name,
-            }
-            _write_repo(content, args.output_path)
+            if not _is_repo_disabled(args, "powertools"):
+                content = POWERTOOLS_REPO_TEMPLATE % {
+                    "mirror": args.mirror,
+                    "stream": stream,
+                    "legacy_url": legacy_url,
+                    "pt_name": pt_name,
+                }
+                _write_repo(content, args.output_path)
+            else:
+                print("Skipping disabled repo: powertools")
 
             if "9" in stream or "10" in stream:
-                content = APPSTREAM_REPO_TEMPLATE % {
-                    "mirror": args.mirror,
-                    "extra": "",
-                    "legacy_url": legacy_url,
-                    "stream": stream,
-                }
-                _write_repo(content, args.output_path)
+                if not _is_repo_disabled(args, "appstream"):
+                    content = APPSTREAM_REPO_TEMPLATE % {
+                        "mirror": args.mirror,
+                        "extra": "",
+                        "legacy_url": legacy_url,
+                        "stream": stream,
+                    }
+                    _write_repo(content, args.output_path)
 
-                content = BASE_REPO_TEMPLATE % {
-                    "mirror": args.mirror,
-                    "legacy_url": legacy_url,
-                    "stream": stream,
-                }
-                _write_repo(content, args.output_path)
+                if not _is_repo_disabled(args, "baseos"):
+                    content = BASE_REPO_TEMPLATE % {
+                        "mirror": args.mirror,
+                        "legacy_url": legacy_url,
+                        "stream": stream,
+                    }
+                    _write_repo(content, args.output_path)
+
+    # Install any extra repos specified via --extra-repo
+    _install_extra_repos(args)
 
 
 def _run_pkg_clean(distro):

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,14 +2,6 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-hacking>=3.0,<=3.1.0  # Apache-2.0
-
-coverage>=4.0,!=4.4  # Apache-2.0
 ddt>=1.0.1 # MIT
-python-subunit>=0.0.18 # Apache-2.0/BSD
-oslotest>=1.10.0 # Apache-2.0
-testrepository>=0.0.18  # Apache-2.0/BSD
-testscenarios>=0.4  # Apache-2.0/BSD
 testtools>=1.4.0 # MIT
 stestr>=2.0.0 # Apache-2.0
-fixtures>=3.0.0 # Apache-2.0/BSD

--- a/tests/unit/repo_setup/test_main.py
+++ b/tests/unit/repo_setup/test_main.py
@@ -109,6 +109,8 @@ class TestTripleORepos(testtools.TestCase):
         args.branch = 'master'
         args.output_path = 'test'
         args.distro = 'fake'
+        args.disable_repo = []
+        args.extra_repo = []
         mock_get.return_value = '[delorean]\nMr. Fusion'
         main._install_repos(args, 'roads/')
         self.assertEqual([mock.call('roads/current/delorean.repo', args),
@@ -129,6 +131,8 @@ class TestTripleORepos(testtools.TestCase):
         args.branch = 'master'
         args.output_path = 'test'
         args.distro = 'fake'
+        args.disable_repo = []
+        args.extra_repo = []
         mock_get.return_value = '[delorean-deps]\nMr. Fusion'
         main._install_repos(args, 'roads/')
         mock_get.assert_called_once_with('roads/delorean-deps.repo', args)
@@ -144,6 +148,8 @@ class TestTripleORepos(testtools.TestCase):
         args.branch = 'master'
         args.output_path = 'test'
         args.distro = 'fake'
+        args.disable_repo = []
+        args.extra_repo = []
         mock_get.return_value = '[delorean]\nMr. Fusion'
         main._install_repos(args, 'roads/')
         self.assertEqual([mock.call('roads/current-podified/delorean.repo',
@@ -165,6 +171,8 @@ class TestTripleORepos(testtools.TestCase):
         args.branch = 'master'
         args.output_path = 'test'
         args.distro = 'fake'
+        args.disable_repo = []
+        args.extra_repo = []
         mock_get.return_value = '[delorean]\nMr. Fusion'
         main._install_repos(args, 'roads/')
         self.assertEqual([mock.call('roads/podified-ci-testing/delorean.repo',
@@ -193,6 +201,8 @@ class TestTripleORepos(testtools.TestCase):
         args.branch = branch
         args.output_path = 'test'
         args.distro = 'fake'
+        args.disable_repo = []
+        args.extra_repo = []
         mock_repo = '[centos-ceph-pacific]\nMr. Fusion'
         mock_create_ceph.return_value = mock_repo
         main._install_repos(args, 'roads/')
@@ -202,6 +212,8 @@ class TestTripleORepos(testtools.TestCase):
     def test_install_repos_invalid(self):
         args = mock.Mock()
         args.repos = ['roads?']
+        args.disable_repo = []
+        args.extra_repo = []
         self.assertRaises(main.InvalidArguments, main._install_repos, args,
                           'roads/')
 
@@ -216,6 +228,8 @@ class TestTripleORepos(testtools.TestCase):
         args.distro = 'centos8'
         args.stream = False
         args.mirror = 'mirror'
+        args.disable_repo = []
+        args.extra_repo = []
         mock_get.return_value = '[delorean]\nMr. Fusion'
         main._install_repos(args, 'roads/')
         self.assertEqual([mock.call('roads/current/delorean.repo', args),
@@ -252,6 +266,8 @@ class TestTripleORepos(testtools.TestCase):
         args.no_stream = False
         args.mirror = 'mirror'
         args.dlrn_hash_tag = None
+        args.disable_repo = []
+        args.extra_repo = []
         mock_get.return_value = '[delorean]\nMr. Fusion'
         main._install_repos(args, 'roads/')
         self.assertEqual([mock.call('roads/current/delorean.repo', args),
@@ -288,6 +304,8 @@ class TestTripleORepos(testtools.TestCase):
         args.stream = True
         args.no_stream = False
         args.mirror = 'mirror'
+        args.disable_repo = []
+        args.extra_repo = []
         mock_get.return_value = '[delorean]\nMr. Fusion'
         main._install_repos(args, 'roads/')
         self.assertEqual([mock.call('roads/current/delorean.repo', args),
@@ -336,6 +354,8 @@ class TestTripleORepos(testtools.TestCase):
         args.stream = False
         args.no_stream = True
         args.mirror = 'mirror'
+        args.disable_repo = []
+        args.extra_repo = []
         mock_get.return_value = '[delorean]\nMr. Fusion'
         main._install_repos(args, 'roads/')
         self.assertEqual([mock.call('roads/current/delorean.repo', args),
@@ -515,6 +535,8 @@ class TestValidate(testtools.TestCase):
         self.distro_major_version_id = "9"
         self.args.stream = False
         self.args.no_stream = False
+        self.args.extra_repo = []
+        self.args.disable_repo = []
 
     def test_good(self):
         main._validate_args(self.args, '', '')
@@ -576,3 +598,145 @@ class TestValidate(testtools.TestCase):
 
     def test_validate_distro_repos(self):
         self.assertTrue(main._validate_distro_repos(self.args))
+
+    def test_validate_extra_repo_valid(self):
+        self.args.extra_repo = [
+            'messaging,'
+            'baseurl=https://mirror.stream.centos.org/SIGs/9-stream/'
+            'messaging/x86_64/rabbitmq-4/'
+        ]
+        main._validate_args(self.args, '', '')
+
+    def test_validate_extra_repo_invalid_no_baseurl(self):
+        self.args.extra_repo = ['bad-format']
+        self.assertRaises(main.InvalidArguments, main._validate_args,
+                          self.args, '', '')
+
+    def test_validate_extra_repo_invalid_empty_name(self):
+        self.args.extra_repo = [',baseurl=https://example.com/repo/']
+        self.assertRaises(main.InvalidArguments, main._validate_args,
+                          self.args, '', '')
+
+    def test_validate_extra_repo_invalid_option(self):
+        self.args.extra_repo = [
+            'myrepo,baseurl=https://example.com/,badopt=foo'
+        ]
+        self.assertRaises(main.InvalidArguments, main._validate_args,
+                          self.args, '', '')
+
+
+class TestExtraRepos(testtools.TestCase):
+    def test_parse_extra_repos(self):
+        result = main._parse_extra_repos([
+            'messaging,'
+            'baseurl=https://mirror.stream.centos.org/SIGs/9-stream/'
+            'messaging/x86_64/rabbitmq-4/'
+        ])
+        self.assertEqual(1, len(result))
+        self.assertEqual('messaging', result[0]['name'])
+        self.assertEqual(
+            'https://mirror.stream.centos.org/SIGs/9-stream/'
+            'messaging/x86_64/rabbitmq-4/',
+            result[0]['baseurl'])
+        self.assertIsNone(result[0]['gpgkey'])
+
+    def test_parse_extra_repos_with_gpgkey(self):
+        result = main._parse_extra_repos([
+            'extras-common,'
+            'baseurl=https://mirror.stream.centos.org/SIGs/9-stream/'
+            'extras/x86_64/extras-common/,'
+            'gpgkey=https://www.centos.org/keys/'
+            'RPM-GPG-KEY-CentOS-SIG-Extras'
+        ])
+        self.assertEqual(1, len(result))
+        self.assertEqual('extras-common', result[0]['name'])
+        self.assertEqual(
+            'https://mirror.stream.centos.org/SIGs/9-stream/'
+            'extras/x86_64/extras-common/',
+            result[0]['baseurl'])
+        self.assertEqual(
+            'https://www.centos.org/keys/RPM-GPG-KEY-CentOS-SIG-Extras',
+            result[0]['gpgkey'])
+
+    def test_parse_extra_repos_multiple(self):
+        result = main._parse_extra_repos([
+            'repo1,baseurl=https://example.com/repo1/',
+            'repo2,baseurl=https://example.com/repo2/',
+        ])
+        self.assertEqual(2, len(result))
+
+    @mock.patch('repo_setup.main._write_repo')
+    def test_install_extra_repos_no_gpgkey(self, mock_write):
+        args = mock.Mock()
+        args.extra_repo = [
+            'messaging,'
+            'baseurl=https://mirror.stream.centos.org/SIGs/9-stream/'
+            'messaging/x86_64/rabbitmq-4/'
+        ]
+        main._install_extra_repos(args)
+        mock_write.assert_called_once()
+        content = mock_write.call_args[0][0]
+        self.assertIn('[repo-setup-messaging]', content)
+        self.assertIn(
+            'baseurl=https://mirror.stream.centos.org/SIGs/9-stream/'
+            'messaging/x86_64/rabbitmq-4/',
+            content)
+        self.assertIn('gpgcheck=0', content)
+        self.assertNotIn('gpgkey=', content)
+        self.assertIn('enabled=1', content)
+
+    @mock.patch('repo_setup.main._write_repo')
+    def test_install_extra_repos_with_gpgkey(self, mock_write):
+        args = mock.Mock()
+        args.extra_repo = [
+            'extras-common,'
+            'baseurl=https://mirror.stream.centos.org/SIGs/9-stream/'
+            'extras/x86_64/extras-common/,'
+            'gpgkey=https://www.centos.org/keys/'
+            'RPM-GPG-KEY-CentOS-SIG-Extras'
+        ]
+        main._install_extra_repos(args)
+        mock_write.assert_called_once()
+        content = mock_write.call_args[0][0]
+        self.assertIn('[repo-setup-extras-common]', content)
+        self.assertIn('gpgcheck=1', content)
+        self.assertIn(
+            'gpgkey=https://www.centos.org/keys/'
+            'RPM-GPG-KEY-CentOS-SIG-Extras',
+            content)
+        self.assertIn('enabled=1', content)
+
+    @mock.patch('repo_setup.main._get_repo')
+    @mock.patch('repo_setup.main._write_repo')
+    def test_disable_repo_ceph(self, mock_write, mock_get):
+        args = mock.Mock()
+        args.repos = ['ceph']
+        args.branch = 'master'
+        args.output_path = 'test'
+        args.distro = 'fake'
+        args.disable_repo = ['ceph']
+        args.extra_repo = []
+        main._install_repos(args, 'roads/')
+        mock_write.assert_not_called()
+
+    @mock.patch('repo_setup.main._get_repo')
+    @mock.patch('repo_setup.main._write_repo')
+    def test_disable_repo_highavailability(self, mock_write, mock_get):
+        args = mock.Mock()
+        args.repos = ['current']
+        args.dlrn_hash_tag = None
+        args.branch = 'master'
+        args.output_path = 'test'
+        args.distro = 'centos9'
+        args.stream = True
+        args.no_stream = False
+        args.mirror = 'mirror'
+        args.disable_repo = ['highavailability']
+        args.extra_repo = []
+        mock_get.return_value = '[delorean]\nMr. Fusion'
+        main._install_repos(args, 'roads/')
+        written_names = [
+            call[0][0] for call in mock_write.call_args_list
+        ]
+        for content in written_names:
+            self.assertNotIn('highavailability', content)

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ setenv =
 passenv =
   HOME
 deps =
-  -c{env:TOX_CONSTRAINTS_FILE:https://releases.openstack.org/constraints/upper/master}
   -r{toxinidir}/test-requirements.txt
   -r{toxinidir}/requirements.txt
 commands =


### PR DESCRIPTION
- Add `--extra-repo NAME,baseurl=URL[,gpgkey=URL]` option to add custom repos (e.g. CentOS SIG repos)
- Add `--disable-repo REPO_NAME` option to skip creating default repos (highavailability, powertools, appstream, baseos, ceph)
- When gpgkey is provided, gpgcheck is enabled automatically

This enables use cases like adding the Messaging SIG repo for RabbitMQ 4.x directly:
```
repo-setup current --extra-repo messaging-rabbitmq-4,baseurl=https://mirror.stream.centos.org/SIGs/9-stream/messaging/x86_64/rabbitmq-4/
```